### PR TITLE
Fixed config schema for hidden_languages option

### DIFF
--- a/config/schema/skilld_lang_dropdown.schema.yml
+++ b/config/schema/skilld_lang_dropdown.schema.yml
@@ -11,7 +11,11 @@ block.settings.lang_drop_down_switcher:*:
       type: sequence
       label: 'Hidden languages'
       sequence:
-        type: string
+        type: sequence
+        label: 'Role'
+        sequence:
+          type: string
+          label: 'Language code'
     display:
       type: integer
       label: 'Display format'


### PR DESCRIPTION
Have an issue with hidden_languages options

`InvalidArgumentException: The configuration property variant_settings.blocks.cd907c50-7ee7-4b56-ad8e-eb6e16aa3f01.hidden_languages.anonymous.0 doesn't exist. in Drupal\Core\Config\Schema\ArrayElement->get() (line 76 of /var/www/html/docroot/core/lib/Drupal/Core/Config/Schema/ArrayElement.php).`
